### PR TITLE
Add Spacify filter to .gitconfig

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+.* filter=spacify

--- a/.gitconfig
+++ b/.gitconfig
@@ -68,3 +68,6 @@
         autosquash = true
 [rerere]
 	enabled = true
+[filter "spacify"]
+        smudge = gexpand --tabs=4
+        clean = gexpand --tabs=4

--- a/spacify-README.txt
+++ b/spacify-README.txt
@@ -1,0 +1,7 @@
+Include the local .gitconfig file :
+git config --local include.path ../.gitconfig
+
+Force a run of the filter:
+rm -rf .git/index && git checkout HEAD -- **
+
+


### PR DESCRIPTION
This allows automatic conversion of tabs to spaces for all
dot files.