### PR TITLE
Replace dumb-jump obsolete interface with xref-backend

### DIFF
--- a/emacs/radian.el
+++ b/emacs/radian.el
@@ -2568,7 +2568,12 @@ order."
     "Like `dumb-jump-go-prompt' but use a different window."
     (interactive)
     (let ((dumb-jump-window 'other))
-      (dumb-jump-go-prompt))))
+      (dumb-jump-go-prompt)))
+
+  (radian-defhook radian--dumb-jump-enable-xref-backend ()
+    xref-backend-functions
+    "Add `dumb-jump-xref-activate' hook to `xref-backend-functions'."
+    #'dumb-jump-xref-activate)))
 
 ;;;; Display contextual metadata
 


### PR DESCRIPTION
`dumb-jump` now uses the [`xref` interface](https://github.com/jacktasia/dumb-jump/blob/ff9fc9360d39f5e07c1f480f8b0656b49606781b/dumb-jump.el#L2992-L3012) so they [suggest](https://github.com/jacktasia/dumb-jump/blob/ff9fc9360d39f5e07c1f480f8b0656b49606781b/dumb-jump.el#L34-L36) to add this `dumb-jump-xref-activate` hook to the `xref-backend-functions`.