### PR TITLE
fix: workaround error regarding unadvised files when byte-compiling

### DIFF
--- a/emacs/radian.el
+++ b/emacs/radian.el
@@ -2916,8 +2916,10 @@ was printed, and only have ElDoc display if one wasn't."
 
   ;; Wherein we hope nobody else is relying on sticking obsolete
   ;; advices onto these functions.
-  (ad-deactivate 'enable-theme)
-  (ad-deactivate 'disable-theme)
+  (when (ad-is-advised #'enable-theme)
+    (ad-deactivate 'enable-theme))
+  (when (ad-is-advised #'disable-theme)
+    (ad-deactivate 'disable-theme))
 
   (radian-defadvice radian--advice-cider-hack-color-calculation (&rest _)
     :before #'cider-docview-fontify-code-blocks


### PR DESCRIPTION
I get this for `enable-theme` and `disable-theme`:

```
$ make compile
...
Error (use-package): cider-doc/:config: ad-deactivate: ‘disable-theme’ is not advised
make: *** [Makefile:25: compile] Error 1
```

Guarding `ad-deactivate` gets rid of the error.