### PR TITLE
Include .gitconfig.local last in .gitconfig.

### DIFF
--- a/git/.gitconfig
+++ b/git/.gitconfig
@@ -37,8 +37,6 @@
 	required = true
 	smudge = git-lfs smudge -- %f
 	process = git-lfs filter-process
-[include]
-	path = ~/.gitconfig.local
 [init]
 	defaultBranch = main
 [merge]
@@ -58,3 +56,6 @@
 	enabled = true
 [status]
 	submodulesummary = true
+# .gitconfig.local should be included last.
+[include]
+	path = ~/.gitconfig.local


### PR DESCRIPTION
Git seems to include files in the order they appear in .gitconfig. For
example, it's not possible to override defaultBranch under init with the
current ordering.