### PR TITLE
fix: update lsp-mode version so typescript server is not broken

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        emacs_version: [27, 28]
+        emacs_version: [27, 28, 29]
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/emacs/versions.el
+++ b/emacs/versions.el
@@ -47,7 +47,7 @@
  ("json-snatcher" . "b28d1c0670636da6db508d03872d96ffddbc10f2")
  ("let-alist" . "021fc10df2e44faba4728d849ee767cf890aa51a")
  ("lsp-haskell" . "daa51072e1718ca075987901fccbbc2357bca1fc")
- ("lsp-mode" . "c9db552dcef80c481ecca6bf53c86a12f2a9cd55")
+ ("lsp-mode" . "01bd566c0508993202b08071ed7037c9fc4e3329")
  ("lsp-pyright" . "c745228f39fdb35372b29b909f25fa6c98dc7c88")
  ("lsp-ui" . "8d4fa5a14f5b5c6f57bc69f454eba6861ed2ba9f")
  ("lua-mode" . "d17a00ca50aee197cd017d573b83367eb241cc44")

--- a/emacs/versions.el
+++ b/emacs/versions.el
@@ -38,7 +38,7 @@
  ("git-modes" . "eca3bb42ea8abed9ef8549b2ac91bbea445c5bb5")
  ("gnu-elpa-mirror" . "a4f2d4b0e1d3dd8bde2d768458a402d63ad06722")
  ("go-mode.el" . "08aa90d52f0e7d2ad02f961b554e13329672d7cb")
- ("haskell-mode" . "5a9f8072c7b9168f0a8409adf9d62a3e4ad4ea3d")
+ ("haskell-mode" . "8d0f44bfe2a9ab6b0969c9bafb75089f315ff5ae")
  ("hcl-mode" . "751b79247f326ab52e00032e805775c37ad9f080")
  ("helpful" . "94a07d49a80f66f8ebc54a49a4b4f6899a65fbe3")
  ("ht.el" . "c4c1be487d6ecb353d07881526db05d7fc90ea87")


### PR DESCRIPTION
The typescript language server `ts-ls` crashes on start-up because of a deprecated argument, which was fixed in
https://github.com/emacs-lsp/lsp-mode/pull/4202

See also https://github.com/doomemacs/doomemacs/issues/7540