### PR TITLE
Require bytecomp

### DIFF
--- a/emacs/radian.el
+++ b/emacs/radian.el
@@ -27,6 +27,7 @@
 (require 'cl-lib)
 (require 'map)
 (require 'subr-x)
+(require 'bytecomp)
 
 ;;; Fix indentation issues
 

--- a/emacs/radian.el
+++ b/emacs/radian.el
@@ -24,10 +24,10 @@
 
 ;;; Load built-in utility libraries
 
+(require 'bytecomp)
 (require 'cl-lib)
 (require 'map)
 (require 'subr-x)
-(require 'bytecomp)
 
 ;;; Fix indentation issues
 


### PR DESCRIPTION
Since `byte-compile-current-file` is used (otherwise byte-compilation fails).