### PR TITLE
Quit minibuffer safely and recursively.

### DIFF
--- a/emacs/radian.el
+++ b/emacs/radian.el
@@ -1086,9 +1086,10 @@ Normally, \\[keyboard-quit] will just act in the current buffer.
 This advice modifies the behavior so that it will instead exit an
 active minibuffer, even if the minibuffer is not selected."
   (if-let* ((minibuffer (active-minibuffer-window)))
-      (progn
-        (switch-to-buffer (window-buffer minibuffer))
+      (with-current-buffer (window-buffer minibuffer)
         (cond
+         ((not (minibuffer-innermost-command-loop-p))
+          (abort-recursive-edit))
          ((featurep 'delsel)
           (progn
             (eval-when-compile


### PR DESCRIPTION
A fix to #567, in case the proposed solution is acceptable.  

EDIT: I changed the implementation so that `abort-recursive-edit` is only called if needed.