### PR TITLE
Add a hook to run after env-setup

### DIFF
--- a/emacs/radian.el
+++ b/emacs/radian.el
@@ -794,6 +794,21 @@ This keymap is bound under \\[radian-keymap].")
 ;;; Environment
 ;;;; Environment variables
 
+(defvar radian-env-setup-hook nil)
+
+(defmacro radian-after-env-setup (&rest forms)
+  "Execute FORMS after environment setup.
+
+If the environment is already setup or is not expected to be setup, just
+executes the forms now."
+  `(let ((fn (lambda () ,@forms)))
+     (if radian-env-setup
+         (progn
+           (add-hook 'radian-env-setup-hook fn)
+           (when radian--env-setup-p
+             (funcall fn)))
+       (funcall fn))))
+
 (defcustom radian-env-setup t
   "Non-nil means ~/.profile is sourced after startup.
 Environment variables will be copied into the current Emacs
@@ -850,7 +865,8 @@ Only do this once, unless AGAIN is non-nil."
                                    (setq exec-path (append
                                                     (parse-colon-path value)
                                                     (list exec-directory)))))
-                        (setq radian--env-setup-p t))
+                        (setq radian--env-setup-p t)
+                        (run-hooks 'radian-env-setup-hook))
                     (message
                      "Loading %s produced malformed result; see buffer %S"
                      profile-file


### PR DESCRIPTION
Implement a way to execute functionality that requires the environment being setup, such as setting paths.