### PR TITLE
use the value of `radian-font-size` not the literal text

### DIFF
--- a/emacs/radian.el
+++ b/emacs/radian.el
@@ -5488,7 +5488,7 @@ turn it off again after creating the first frame."
   ;; Set the default font size.
   (when radian-font-size
     (custom-theme-set-faces
-     'user '(default ((t (:height radian-font-size))) t)))
+     'user `(default ((t (:height ,radian-font-size))) t)))
 
   ;; Set the default font. No, I have no idea why we have to do it
   ;; this way. Using `set-face-attribute' does not have an effect,


### PR DESCRIPTION
Otherwise I get the error `Default face height not absolute and positive`