### PR TITLE
Various fixes

### DIFF
--- a/emacs/init.el
+++ b/emacs/init.el
@@ -40,10 +40,6 @@ loading the init-file twice if it were not for this variable.")
     ;; Prevent package.el from modifying this file.
     (setq package-enable-at-startup nil)
 
-    ;; Prevent Custom from modifying this file.
-    (setq custom-file (expand-file-name "custom.el" user-emacs-directory))
-    (load custom-file 'noerror 'nomessage)
-
     ;; Make sure we are running a modern enough Emacs, otherwise abort
     ;; init.
     (if (version< emacs-version radian-minimum-emacs-version)
@@ -82,6 +78,10 @@ init-file is loaded, not just once.")
         (defvar radian-original-file-name-handler-alist nil
           "The value of `file-name-handler-alist' during load time.
 `file-name-handler-alist' is set to nil while Radian is loading.")
+
+        ;; Prevent Custom from modifying this file.
+        (setq custom-file (expand-file-name "custom.el" user-emacs-directory))
+        (load custom-file 'noerror 'nomessage)
 
         (unwind-protect
             ;; Load the main Radian configuration code. Disable

--- a/emacs/radian.el
+++ b/emacs/radian.el
@@ -1333,7 +1333,10 @@ arguments."
         (dirs-to-delete ()))
     ;; If the file already exists, we don't need to worry about
     ;; creating any directories.
-    (unless (file-exists-p filename)
+    (unless (or (file-exists-p filename)
+                ;; If the buffer is already open, we should not create a
+                ;; directory.
+                (get-file-buffer filename))
       ;; It's easy to figure out how to invoke `make-directory',
       ;; because it will automatically create all parent
       ;; directories. We just need to ask for the directory

--- a/emacs/radian.el
+++ b/emacs/radian.el
@@ -4270,7 +4270,7 @@ messages."
       (when report-progress
         (message "Byte-compiling updated configuration..."))
       (when (process-live-p radian-byte-compile--process)
-        (kill-process radian-byte-compile--process))
+        (delete-process radian-byte-compile--process))
       (ignore-errors
         (with-current-buffer (get-buffer " *radian-byte-compile*")
           (kill-all-local-variables)

--- a/emacs/radian.el
+++ b/emacs/radian.el
@@ -4861,8 +4861,8 @@ as argument."
   (radian-defadvice radian--magit-version-from-snapshot (&rest _)
     :before #'magit-version
     "Allow `magit-version' to work even from straight.el snapshot."
-    (when-let ((lisp-filename (let ((load-suffixes (reverse load-suffixes)))
-                                (locate-library "magit"))))
+    (when-let* ((lisp-filename (let ((load-suffixes (reverse load-suffixes)))
+                                 (locate-library "magit"))))
       (setq lisp-filename (magit--chase-links lisp-filename))
       (let ((commit-filename
              (expand-file-name


### PR DESCRIPTION
I have four fixes that I hope are OK to submit as one PR. I recommend not squashing them, as they address separate issues.

The motivations are:

- Currently, if a file is deleted while its buffer is open, there is a chance that a directory will be created for the buffer. For me, this manifested as repeatedly deleting the directory containing an open buffer's file, only for Radian to recreate it.
- Using `when-let` (unstarred) produces a compilation warning.
- `custom-file` is currently loaded before any Radian variables are defined. This is the only file that is not compiled as part of Radian, so I wanted to use it to check whether Radian needs to be recompiled (for custom-related reasons). However, the Radian variables are not defined when it is loaded. Is there a reason why `custom` is loaded so early in Radian's initialisation cycle?
- `kill-process` is asynchronous. I believe we want `delete-process` here to ensure that we can start a new process with the same name.